### PR TITLE
Add Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 .history
 .svn/
 
+# Coverage
+coverage/
+
 # IntelliJ related
 *.iml
 *.ipr


### PR DESCRIPTION
Coverage: https://pub.dev/packages/coverage

Install Coverage:
 - `dart pub global activate coverage`

Run tests with Coverage:
 - Run `dart pub global run coverage:test_with_coverage`
 - Result is saved in `coverage/lcov.info`
 
If you don't have lcov tool installed on your Mac, run `brew install lcov`  to install it. Then you can generate coverage reports using genhtml command `genhtml -o coverage coverage/lcov.info` and then see the report by the command `open coverage/index.html`.


